### PR TITLE
Update rtcWinSocket.pas

### DIFF
--- a/src/Lib/rtcWinSocket.pas
+++ b/src/Lib/rtcWinSocket.pas
@@ -1447,6 +1447,14 @@ procedure TRtcWinSocket.Listen;
     end
   else
     begin
+    optval  := -1;
+    // this might fail, if we do NOT have Administrative privileges ...
+    iStatus := _setsockopt(FHSocket, SOL_SOCKET, -5 {SO_EXCLUSIVEADDRUSE}, @optval, SizeOf(optval));
+    if iStatus <> 0 then
+      begin
+      // RealSocketError('setsockopt(SO_EXCLUSIVEADDRUSE)',False);
+      // Exit;
+      end;
     optval := -1; { -1=true, 0=false }
     iStatus := _setsockopt(FHSocket, IPPROTO_TCP, TCP_NODELAY, @optval, SizeOf(optval));
     if iStatus <> 0 then


### PR DESCRIPTION
Try to set SO_EXCLUSIVEADDRESSUSE option in Listen for WinSock Servers. Ignore if setting this option fails, since Administrative privileges might be required for that.